### PR TITLE
fix(ci): use per-file check in dependabot auto-merge validation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -42,10 +42,10 @@ jobs:
               'yarn.lock',
               'bun.lock',
             ]
-            const isGHA = filenames.every(f => f.startsWith('.github/'))
-            const isDeps = filenames.every(f => allowed.includes(f))
-            if (!isGHA && !isDeps) {
-              core.setFailed('PR touches files outside dependency manifests and .github/')
+            const safe = filenames.every(f => f.startsWith('.github/') || allowed.includes(f))
+            if (!safe) {
+              const unsafe = filenames.filter(f => !f.startsWith('.github/') && !allowed.includes(f))
+              core.setFailed(`PR touches files outside dependency manifests and .github/: ${unsafe.join(', ')}`)
             }
       - name: Enable auto-merge for minor/patch dependency updates
         if: steps.diff.outcome == 'success' && steps.labels.outcome == 'success'


### PR DESCRIPTION
## Summary
- Replace dual `every()` checks with a single per-file predicate in dependabot auto-merge workflow
- Mixed-category PRs (`.github/` files + dependency manifests) were incorrectly rejected
- Unsafe files are now listed in the failure message for easier debugging

## Context
Identified by CodeRabbit on #37. Upstream issue: nathanvale/bun-typescript-starter#66

## Test plan
- [ ] Verify workflow syntax is valid (GitHub Actions lint)
- [ ] Confirm existing dependabot PRs (deps-only or GHA-only) still auto-merge
- [ ] Mixed-category PRs (if they ever occur) would now pass the file check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal CI/CD workflow checks for improved dependency management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->